### PR TITLE
fix mazesetup/plonk fullproof by updating circom_runtime version

### DIFF
--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -13703,7 +13703,7 @@ async function plonkExportSolidityCallData(_proof, _pub) {
     Fr.toRprBE(proofBuff, G1.F.n8*18 + Fr.n8*3, Fr.e(proof.eval_s1));
     Fr.toRprBE(proofBuff, G1.F.n8*18 + Fr.n8*4, Fr.e(proof.eval_s2));
     Fr.toRprBE(proofBuff, G1.F.n8*18 + Fr.n8*5, Fr.e(proof.eval_zw));
-    Fr.toRprBE(proofBuff, G1.F.n8*18 + Fr.n8*6, Fr.e(proof.eval_r));
+    Fr.toRprBE(proofBuff, G1.F.n8*18 + Fr.n8*6, For.e(proof.eval_r));
 
     const proofHex = Array.from(proofBuff).map(i2hex).join("");
 

--- a/build/main.cjs
+++ b/build/main.cjs
@@ -13689,7 +13689,7 @@ async function plonkExportSolidityCallData(_proof, _pub) {
     Fr.toRprBE(proofBuff, G1.F.n8*18 + Fr.n8*3, Fr.e(proof.eval_s1));
     Fr.toRprBE(proofBuff, G1.F.n8*18 + Fr.n8*4, Fr.e(proof.eval_s2));
     Fr.toRprBE(proofBuff, G1.F.n8*18 + Fr.n8*5, Fr.e(proof.eval_zw));
-    Fr.toRprBE(proofBuff, G1.F.n8*18 + Fr.n8*6, Fr.e(proof.eval_r));
+    Fr.toRprBE(proofBuff, G1.F.n8*18 + Fr.n8*6, For.e(proof.eval_r));
 
     const proofHex = Array.from(proofBuff).map(i2hex).join("");
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@iden3/binfileutils": "0.0.11",
     "bfj": "^7.0.2",
     "blake2b-wasm": "^2.4.0",
-    "circom_runtime": "0.1.18",
+    "circom_runtime": "0.1.21",
     "circomlibjs": "^0.1.7",
     "ejs": "^3.1.6",
     "fastfile": "0.0.20",


### PR DESCRIPTION
the mazesetup or "plonk full prove" is broken due to circom_runtime dependency issue.